### PR TITLE
Add timestamps to historical data & update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv/
 
 .venv/
 

--- a/test/get_bulk_data_timestamp.py
+++ b/test/get_bulk_data_timestamp.py
@@ -1,19 +1,30 @@
 import json
 from datetime import datetime, timezone
 
-def get_bulk_data_timestamps(json_path='osrs_bulk_data.json'):
+def get_bulk_data_and_timestamp(json_path='osrs_bulk_data.json'):
     with open(json_path, 'r') as f:
         data = json.load(f)
-    # Extract and convert timestamps
-    def to_iso(ts):
+    # Extract special timestamp keys
+    jagex_timestamp = data.get('%JAGEX_TIMESTAMP%')
+    update_detected = data.get('%UPDATE_DETECTED%')
+    # Remove special keys from the main data if needed
+    item_data = {k: v for k, v in data.items() if not k.startswith('%')}
+
+    # Convert timestamps to readable format if they exist
+    def to_readable(ts):
         if ts is None:
             return None
-        return datetime.fromtimestamp(int(float(ts)), tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    return {
-        "Jagex Timestamp": to_iso(data.get('%JAGEX_TIMESTAMP%')),
-        "Update Detected": to_iso(data.get('%UPDATE_DETECTED%'))
-    }
+        # If float, convert to int (for seconds)
+        ts = int(float(ts))
+        return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+    jagex_timestamp_readable = to_readable(jagex_timestamp)
+    update_detected_readable = to_readable(update_detected)
+
+    return item_data, jagex_timestamp_readable, update_detected_readable
 
 # Example usage:
-timestamps = get_bulk_data_timestamps()
-print(timestamps)
+items, jagex_ts, update_ts = get_bulk_data_and_timestamp()
+print(f"Jagex Timestamp: {jagex_ts}")
+print(f"Update Detected: {update_ts}")
+print(f"Total number of items: {len(items)}")

--- a/test/get_historical_data.py
+++ b/test/get_historical_data.py
@@ -1,5 +1,6 @@
-import json
 import requests
+import json
+from datetime import datetime, timezone
 
 def fetch_historical_data(item_id):
     url = f"https://api.weirdgloop.org/exchange/history/osrs/all?id={item_id}"
@@ -8,26 +9,26 @@ def fetch_historical_data(item_id):
         response.raise_for_status()
         data = response.json()
         return data
-    except requests.exceptions.HTTPError as http_err:
-        print(f"HTTP error occurred: {http_err}")
-    except Exception as err:
-        print(f"Other error occurred: {err}")
-    return None
+    except Exception as e:
+        print(f"Error: {e}")
+        return None
 
 def main():
-    # Example item ID for Coal (453)
-    item_id = 2
-
-    
-    # Fetch all historical data for the item
+    item_id = 327  # Example item ID
     all_data = fetch_historical_data(item_id)
-    
-    if all_data:
-        # Save the data to a JSON file
-        file_name = f"historical_data_{item_id}.json"
-        with open(file_name, 'w') as file:
-            json.dump(all_data, file, indent=4)
-        print(f"Data for item ID {item_id} has been saved to {file_name}")
+    print("Raw API response:")
+    print(json.dumps(all_data, indent=2))
+
+    if all_data is not None:
+        # Print the first 5 entries with human-readable timestamps
+        item_history = all_data.get(str(item_id), [])
+        print("\nFirst 5 entries with readable timestamps:")
+        for entry in item_history[:5]:
+            ts = entry['timestamp']
+            date_str = datetime.fromtimestamp(ts / 1000, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+            print(f"Timestamp: {ts} -> {date_str}, Price: {entry['price']}, Volume: {entry['volume']}")
+    else:
+        print("No data returned from API.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Added logic to print and translate timestamps for historical data entries, making it easier to inspect and analyze the time range of available data.
- Updated .gitignore to exclude the venv/ directory and prevent accidental commits of the virtual environment.

**Project pivot:**  
We’ve decided to temporarily move away from building a full bulk data database and instead focus on a single dataset for a handful of items. This will allow us to:
- Apply and experiment with statistical analysis on a manageable dataset.
- Prove the length and quality of the historical data available for individual items.
- Avoid the complexity of full-scale data ingestion and booking at this stage.

This PR lays the groundwork for our new direction by ensuring we can easily inspect and work with historical data for single items.